### PR TITLE
Feature to save Qaava QGIS projects to database

### DIFF
--- a/Qaava/core/db/db_utils.py
+++ b/Qaava/core/db/db_utils.py
@@ -41,6 +41,8 @@ from qgis.core import QgsAuthMethodConfig, QgsApplication, QgsAuthManager, QgsDa
 from ...core.exceptions import QaavaDatabaseNotSetException, QaavaAuthConfigException
 from ...definitions.constants import (PG_CONNECTIONS, QGS_SETTINGS_PSYCOPG2_PARAM_MAP)
 from ...model.land_use_plan import LandUsePlanEnum
+from ...qgis_plugin_tools.tools.custom_logging import bar_msg
+from ...qgis_plugin_tools.tools.i18n import tr
 from ...qgis_plugin_tools.tools.resources import plugin_name
 from ...qgis_plugin_tools.tools.settings import parse_value, set_setting, get_setting
 
@@ -88,6 +90,7 @@ def set_auth_cfg(plan: LandUsePlanEnum, auth_cfg_id: str, username: str, passwor
     :param username:
     :param password:
     """
+    # noinspection PyArgumentList
     auth_mgr: QgsAuthManager = QgsApplication.authManager()
     if auth_cfg_id in auth_mgr.availableAuthMethodConfigs().keys():
         config = QgsAuthMethodConfig()
@@ -171,12 +174,15 @@ def get_db_connection_params(plan: LandUsePlanEnum) -> {str: str}:
         LOGGER.debug(f"Auth cfg: {auth_cfg_id}")
         # Auth config is being used to store the username and password
         auth_config = QgsAuthMethodConfig()
+        # noinspection PyArgumentList
         QgsApplication.authManager().loadAuthenticationConfig(auth_cfg_id, auth_config, True)
 
         if auth_config.isValid():
             params["user"] = auth_config.configMap().get("username")
             params["password"] = auth_config.configMap().get("password")
         else:
-            raise QaavaAuthConfigException()
+            raise QaavaAuthConfigException(
+                tr("Auth config error occurred while fetching database connection parameters"),
+                bar_msg=bar_msg(tr(f"Check auth config with id: {auth_cfg_id}")))
 
     return params

--- a/Qaava/core/db/qgis_project_utils.py
+++ b/Qaava/core/db/qgis_project_utils.py
@@ -47,7 +47,6 @@ def load_project(project_name: str, plan: LandUsePlanEnum) -> None:
     if not succeeded:
         raise QaavaProjectNotLoadedException()
 
-
 def fix_data_sources_from_binary_projects(conn_params: Dict[str, str], auth_cfg_id: str, contents: List[bytes]):
     """
     Fix data sources from binary representation of zipped QGIS project

--- a/Qaava/core/db/qgis_project_utils.py
+++ b/Qaava/core/db/qgis_project_utils.py
@@ -1,0 +1,91 @@
+#  Gispo Ltd., hereby disclaims all copyright interest in the program Qaava-qgis-plugin
+#  Copyright (C) 2020 Gispo Ltd (https://www.gispo.fi/).
+#
+#
+#  This file is part of Qaava-qgis-plugin.
+#
+#  Qaava-qgis-plugin is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  Qaava-qgis-plugin is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Qaava-qgis-plugin.  If not, see <https://www.gnu.org/licenses/>.
+import binascii
+import io
+import logging
+import re
+import zipfile
+from typing import List, Dict
+from zipfile import ZipFile
+
+from qgis.core import (QgsProject)
+
+from .db_utils import get_db_connection_pg_uri
+from ..exceptions import QaavaProjectNotLoadedException, QaavaProjectInInvalidFormat
+from ...model.land_use_plan import LandUsePlanEnum
+from ...qgis_plugin_tools.tools.resources import plugin_name
+
+LOGGER = logging.getLogger(plugin_name())
+
+
+def load_project(project_name: str, plan: LandUsePlanEnum) -> None:
+    """
+    Load QGIS project from the database
+    :param project_name: Name of the project
+    :param plan: land use plan
+    """
+    # noinspection PyArgumentList
+    project = QgsProject.instance()
+    uri = get_db_connection_pg_uri(plan, project_name)
+    succeeded = project.read(uri)
+    if not succeeded:
+        raise QaavaProjectNotLoadedException()
+
+
+def fix_data_sources_from_binary_projects(conn_params: Dict[str, str], auth_cfg_id: str, contents: List[bytes]):
+    """
+    Fix data sources from binary representation of zipped QGIS project
+    :param conn_params: connection parameters of the db connection
+    :param auth_cfg_id: auth config id of the connection
+    :param contents: list of binary QGIS project zip files
+    :return: list of binary QGIS project zip files with correct data sources
+    """
+    host = conn_params['host']
+    port = conn_params['port']
+    dbname = conn_params['dbname']
+    ret_vals = []
+    conn_string = f"dbname='{dbname}' host={host} port={port} authcfg={auth_cfg_id}"
+    for i, content in enumerate(contents):
+        z = io.BytesIO()
+        z.write(content)
+        files = extract_zip(z)
+        assert len(files) == 2
+        qgs_f_key = [f for f in files.keys() if f.endswith('.qgs')][0]
+        qgs_proj_content = files[qgs_f_key].decode('utf-8')
+
+        # Replace all connection string from layers with the db specific connection string
+        qgs_proj_content = re.sub(r'dbname=.*host=.*port=\d{4}', conn_string, qgs_proj_content)
+        if conn_string not in qgs_proj_content:
+            raise QaavaProjectInInvalidFormat()
+        files[qgs_f_key] = bytes(qgs_proj_content, 'utf-8')
+        ret_vals.append(create_in_memory_zip(files))
+    return ret_vals
+
+
+def extract_zip(input_zip):
+    input_zip = ZipFile(input_zip)
+    return {name: input_zip.read(name) for name in input_zip.namelist()}
+
+
+def create_in_memory_zip(contents: Dict[str, bytes]) -> bytes:
+    zip_buffer = io.BytesIO()
+    with ZipFile(zip_buffer, "a", zipfile.ZIP_DEFLATED, False) as zip_file:
+        for file_name, data in contents.items():
+            zip_file.writestr(file_name, io.BytesIO(data).getvalue())
+    return binascii.hexlify(zip_buffer.getvalue())

--- a/Qaava/core/exceptions.py
+++ b/Qaava/core/exceptions.py
@@ -43,3 +43,11 @@ class QaavaDatabaseNotSetException(QgsPluginException):
 
 class QaavaAuthConfigException(QgsPluginException):
     pass
+
+
+class QaavaProjectNotLoadedException(QgsPluginException):
+    pass
+
+
+class QaavaProjectInInvalidFormat(QgsPluginException):
+    pass

--- a/Qaava/core/exceptions.py
+++ b/Qaava/core/exceptions.py
@@ -51,3 +51,11 @@ class QaavaProjectNotLoadedException(QgsPluginException):
 
 class QaavaProjectInInvalidFormat(QgsPluginException):
     pass
+
+
+class QaavaInitializationCancelled(QgsPluginException):
+    pass
+
+
+class QaavaDatabaseError(QgsPluginException):
+    pass

--- a/Qaava/definitions/constants.py
+++ b/Qaava/definitions/constants.py
@@ -36,10 +36,13 @@
 from ..qgis_plugin_tools.tools.settings import setting_key
 
 # Urls
-QAAVA_GITHUB_URL = "https://raw.githubusercontent.com/GispoCoding/qaava"
+QAAVA_GITHUB_URL = "https://raw.githubusercontent.com/GispoCoding/qaava/master"
 
-DETAILED_PLAN_DATA_MODEL_URL = f"{QAAVA_GITHUB_URL}/master/asemakaavan-tietomalli/tietomalli_luonnos.sql"
-GENERAL_PLAN_DATA_MODEL_URL = f"{QAAVA_GITHUB_URL}/master/yleiskaavan-tietomalli/tietomalli_luonnos.sql"
+DETAILED_PLAN_DATA_MODEL_URL = f"{QAAVA_GITHUB_URL}/asemakaavan-tietomalli/tietomalli_luonnos.sql"
+GENERAL_PLAN_URL = f"{QAAVA_GITHUB_URL}/yleiskaavan-tietomalli"
+GENERAL_PLAN_DATA_VERSIONS_URL = f"{GENERAL_PLAN_URL}/versions.txt"
+GENERAL_PLAN_MODEL_FILE_NAME = 'yleiskaavan-tietomalli.sql'
+GENERAL_PLAN_PROJECT_FILE_NAME = 'yleiskaava-projekti.sql'
 
 # Database
 PG_CONNECTIONS = "PostgreSQL/connections"

--- a/Qaava/model/land_use_plan.py
+++ b/Qaava/model/land_use_plan.py
@@ -16,35 +16,22 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with Qaava-qgis-plugin.  If not, see <https://www.gnu.org/licenses/>.
-#
-#
-#  This file is part of Qaava-qgis-plugin.
-#
-#  Qaava-qgis-plugin is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 2 of the License, or
-#  (at your option) any later version.
-#
-#  Qaava-qgis-plugin is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License
-#  along with Qaava-qgis-plugin.  If not, see <https://www.gnu.org/licenses/>.
 
 import enum
-from typing import Union
+from typing import Union, Dict
 
+from ..core.db.qgis_project_utils import fix_data_sources_from_binary_projects
 from ..definitions.constants import (DETAILED_PLAN_DATA_MODEL_URL, QAAVA_DB_NAME, GENERAL_PLAN_DATA_MODEL_URL)
 from ..qgis_plugin_tools.tools.network import fetch
+from ..qgis_plugin_tools.tools.resources import resources_path
 
 
 class LandUsePlan:
     key = ""
+    auth_cfg_id = ""
     schema_url = ""
-    available_versions = []
     newest_version = None
+    enum = None
 
     def __init__(self):
         self.raw_schema: Union[str, None] = None
@@ -58,6 +45,27 @@ class LandUsePlan:
         self.raw_schema = fetch(self.schema_url)
         self._alter_schema()  # TODO: This is just temporary solution, remove when this is not needed anymore
         return self.schema
+
+    def fetch_project(self, conn_params: Dict[str, str], auth_cfg_id: str) -> str:
+        """
+        :return: project sql
+        """
+        # TODO: fetch from github
+
+        with open(resources_path('qgis_projects.sql')) as f:
+            content = f.read()
+        content = self.fix_project(auth_cfg_id, conn_params, content)
+
+        return content
+
+    def fix_project(self, auth_cfg_id, conn_params, content):
+        proj_bytes = [line.split(',')[5][4:-3] for line in content.split('\n') if
+                      line.startswith('INSERT INTO public.qgis_projects')]
+        byts = [bytes.fromhex(b) for b in proj_bytes]
+        ret_vals = fix_data_sources_from_binary_projects(conn_params, auth_cfg_id=auth_cfg_id, contents=byts)
+        for i in range(len(proj_bytes)):
+            content = content.replace(proj_bytes[i], ret_vals[i].decode('utf-8'))
+        return content
 
     def _alter_schema(self):
         """
@@ -79,11 +87,13 @@ class LandUsePlan:
 
 class DetailedLandUsePlan(LandUsePlan):
     key = f"{QAAVA_DB_NAME}/detailed"
+    auth_cfg_key = f"{key}/auth_cfg"
     schema_url = DETAILED_PLAN_DATA_MODEL_URL
 
 
 class GeneralLandUsePlan(LandUsePlan):
     key = f"{QAAVA_DB_NAME}/general"
+    auth_cfg_key = f"{key}/auth_cfg"
     schema_url = GENERAL_PLAN_DATA_MODEL_URL
 
 

--- a/Qaava/resources.py
+++ b/Qaava/resources.py
@@ -1,40 +1,5 @@
 # -*- coding: utf-8 -*-
 
-#  Gispo Ltd., hereby disclaims all copyright interest in the program Qaava-qgis-plugin
-#  Copyright (C) 2020 Gispo Ltd (https://www.gispo.fi/).
-#
-#
-#  This file is part of Qaava-qgis-plugin.
-#
-#  Qaava-qgis-plugin is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 2 of the License, or
-#  (at your option) any later version.
-#
-#  Qaava-qgis-plugin is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License
-#  along with Qaava-qgis-plugin.  If not, see <https://www.gnu.org/licenses/>.
-#
-#
-#  This file is part of Qaava-qgis-plugin.
-#
-#  Qaava-qgis-plugin is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 2 of the License, or
-#  (at your option) any later version.
-#
-#  Qaava-qgis-plugin is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License
-#  along with Qaava-qgis-plugin.  If not, see <https://www.gnu.org/licenses/>.
-
 # Resource object code
 #
 # Created by: The Resource Compiler for PyQt5 (Qt v5.12.8)

--- a/Qaava/resources/ui/main_dialog.ui
+++ b/Qaava/resources/ui/main_dialog.ui
@@ -126,112 +126,216 @@
             <number>0</number>
            </property>
            <widget class="QWidget" name="database">
-            <layout class="QVBoxLayout" name="verticalLayout_12">
+            <layout class="QVBoxLayout" name="verticalLayout_13">
              <item>
-              <layout class="QVBoxLayout" name="verticalLayout_10">
-               <item>
-                <widget class="QGroupBox" name="groupBox_6">
-                 <property name="title">
-                  <string>Database initialization</string>
-                 </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_11">
-                  <item>
-                   <widget class="QLabel" name="label_3">
-                    <property name="text">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This utility will turn PostgreSQL/PostGIS
-                      database into
-                      a Qaava land use planning database. &lt;/p&gt;&lt;p&gt;At the moment there are 2 possible database
-                      models to
-                      choose from: &lt;a href=&quot;https://github.com/GispoCoding/qaava/tree/master/asemakaavan-tietomalli&quot;&gt;&lt;span
-                      style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;a detailed land use plan database
-                      model&lt;/span&gt;&lt;/a&gt;
-                      and a general plan database model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-                     </string>
-                    </property>
-                    <property name="wordWrap">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
+              <widget class="QGroupBox" name="groupBox_6">
+               <property name="title">
+                <string>Database configuration</string>
+               </property>
+               <layout class="QVBoxLayout" name="verticalLayout_12">
+                <item>
+                 <widget class="QLabel" name="label_3">
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;At the moment there are 2 possible database
+                    models to choose from: &lt;a href=&quot;https://github.com/GispoCoding/qaava/tree/master/asemakaavan-tietomalli&quot;&gt;&lt;span
+                    style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;a detailed land use plan database
+                    model&lt;/span&gt;&lt;/a&gt; and a general plan database model. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+                   </string>
+                  </property>
+                  <property name="wordWrap">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <layout class="QGridLayout" name="gridLayout_6">
+                  <item row="1" column="1" colspan="2">
+                   <widget class="QComboBox" name="dmComboBox"/>
                   </item>
-                  <item>
-                   <layout class="QGridLayout" name="gridLayout_6">
-                    <item row="0" column="0">
-                     <widget class="QLabel" name="dbLabel">
-                      <property name="text">
-                       <string>Available PostGIS databases</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="0" column="1">
-                     <widget class="QComboBox" name="dbComboBox">
-                      <property name="currentText">
-                       <string/>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="0">
-                     <widget class="QLabel" name="dmLabel">
-                      <property name="text">
-                       <string>Data Model for the database</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="1" colspan="2">
-                     <widget class="QComboBox" name="dmComboBox"/>
-                    </item>
-                    <item row="0" column="2">
-                     <widget class="QPushButton" name="refreshPushButton">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="text">
-                       <string>Refresh</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item>
-                   <widget class="QCheckBox" name="agreedCheckBox">
-                    <property name="text">
-                     <string>I understand that this action might erase all content in the database</string>
+                  <item row="0" column="1">
+                   <widget class="QComboBox" name="dbComboBox">
+                    <property name="currentText">
+                     <string/>
                     </property>
                    </widget>
                   </item>
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_4">
-                    <item>
-                     <spacer name="horizontalSpacer_2">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="btn_db_initialize">
-                      <property name="text">
-                       <string>Initialize</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="dbLabel">
+                    <property name="text">
+                     <string>Available PostGIS databases</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="2">
+                   <widget class="QPushButton" name="refreshPushButton">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>Refresh</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="dmLabel">
+                    <property name="text">
+                     <string>Data Model for the database</string>
+                    </property>
+                   </widget>
                   </item>
                  </layout>
-                </widget>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="horizontalLayout_3"/>
-               </item>
-              </layout>
+                </item>
+                <item>
+                 <widget class="QgsCollapsibleGroupBox" name="mGroupBox">
+                  <property name="title">
+                   <string>Initialization</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_10">
+                   <item>
+                    <widget class="QLabel" name="label_4">
+                     <property name="text">
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This utility will turn existing
+                       PostgreSQL/PostGIS database into a Qaava land use planning database. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+                      </string>
+                     </property>
+                     <property name="wordWrap">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QCheckBox" name="agreedCheckBox">
+                     <property name="text">
+                      <string>I understand that this action might erase all content in the database</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <layout class="QHBoxLayout" name="horizontalLayout_4">
+                     <item>
+                      <spacer name="horizontalSpacer_2">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item>
+                      <widget class="QPushButton" name="btn_db_initialize">
+                       <property name="text">
+                        <string>Initialize</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                   <item>
+                    <widget class="Line" name="line">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="label_6">
+                     <property name="text">
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This utility will use existing
+                       PostgreSQL/PostGIS database as a Qaava land use planning database. Make sure to use a correct
+                       model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+                      </string>
+                     </property>
+                     <property name="wordWrap">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <layout class="QHBoxLayout" name="horizontalLayout_6">
+                     <item>
+                      <spacer name="horizontalSpacer_4">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item>
+                      <widget class="QPushButton" name="btn_db_register">
+                       <property name="text">
+                        <string>Register as a land use model default connection</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QgsCollapsibleGroupBox" name="mGroupBox_2">
+                  <property name="title">
+                   <string>QGIS projects</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_11">
+                   <item>
+                    <layout class="QHBoxLayout" name="horizontalLayout_5">
+                     <item>
+                      <widget class="QLabel" name="label_2">
+                       <property name="text">
+                        <string>Available Projects:</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_3">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item>
+                      <widget class="QComboBox" name="cb_projects">
+                       <property name="minimumSize">
+                        <size>
+                         <width>200</width>
+                         <height>0</height>
+                        </size>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QPushButton" name="btn_db_open_project">
+                       <property name="text">
+                        <string>Open</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
              </item>
              <item>
               <spacer name="verticalSpacer_3">
@@ -489,6 +593,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/Qaava/test/conftest.py
+++ b/Qaava/test/conftest.py
@@ -60,6 +60,7 @@ CONN_NAME = "test_qaava_conn"
 @pytest.fixture(scope='function')
 def new_project() -> None:
     """Initializes new iface project"""
+    remove_db_settings()
     yield IFACE.newProject()
 
 
@@ -73,6 +74,18 @@ def initialize_db_settings(database_params) -> str:
 @pytest.fixture(scope='function')
 def initialize_db_settings2(database_params):
     set_settings(database_params, has_pwd=False)
+    yield CONN_NAME
+    remove_db_settings()
+
+
+@pytest.fixture(scope='function')
+def auth_cfg(database_params):
+    prms = database_params.copy()
+    prms.pop('user')
+    prms.pop('password')
+    set_settings(prms, has_pwd=False, auth_cfg='test_config')
+    QGIS_APP.authManager()
+    # TODO: continue
     yield CONN_NAME
     remove_db_settings()
 
@@ -160,7 +173,7 @@ def is_responsive(params):
     return succeeds
 
 
-def set_settings(prms, has_pwd=True):
+def set_settings(prms, has_pwd=True, auth_cfg="NULL"):
     s = QSettings()
     s.setValue(f"{PG_CONNECTIONS}/{CONN_NAME}/host", prms["host"])
     s.setValue(f"{PG_CONNECTIONS}/{CONN_NAME}/port", prms["port"])
@@ -169,7 +182,7 @@ def set_settings(prms, has_pwd=True):
     s.setValue(f"{PG_CONNECTIONS}/{CONN_NAME}/password", prms["password"])
     s.setValue(f"{PG_CONNECTIONS}/{CONN_NAME}/savePassword", "true" if has_pwd else "false")
     s.setValue(f"{PG_CONNECTIONS}/{CONN_NAME}/saveUsername", "true" if has_pwd else "false")
-    s.setValue(f"{PG_CONNECTIONS}/{CONN_NAME}/authcfg", "NULL")
+    s.setValue(f"{PG_CONNECTIONS}/{CONN_NAME}/authcfg", auth_cfg)
 
 
 def remove_db_settings():

--- a/Qaava/test/test_db_tools.py
+++ b/Qaava/test/test_db_tools.py
@@ -55,7 +55,7 @@ def test_get_existing_database_connections_1(initialize_db_settings):
     assert connections == {CONN_NAME}
 
 
-def test_qaava_connection_url_exception():
+def test_qaava_connection_url_exception(new_project):
     with pytest.raises(QaavaDatabaseNotSetException):
         assert get_db_connection_params(LandUsePlanEnum.detailed)
 

--- a/Qaava/test/test_db_tools.py
+++ b/Qaava/test/test_db_tools.py
@@ -35,7 +35,7 @@
 
 import pytest
 
-from .conftest import (remove_db_settings, CONN_NAME, QGIS_APP)
+from .conftest import (remove_db_settings, CONN_NAME)
 from ..core.db.db_utils import (get_existing_database_connections, set_qaava_connection,
                                 get_db_connection_params)
 from ..core.exceptions import QaavaDatabaseNotSetException
@@ -57,18 +57,18 @@ def test_get_existing_database_connections_1(initialize_db_settings):
 
 def test_qaava_connection_url_exception():
     with pytest.raises(QaavaDatabaseNotSetException):
-        assert get_db_connection_params(LandUsePlanEnum.detailed, QGIS_APP)
+        assert get_db_connection_params(LandUsePlanEnum.detailed)
 
 
 def test_qaava_connection_params(initialize_db_settings, database_params):
     set_qaava_connection(LandUsePlanEnum.general, CONN_NAME)
-    params = get_db_connection_params(LandUsePlanEnum.general, QGIS_APP)
+    params = get_db_connection_params(LandUsePlanEnum.general)
     assert params == database_params
 
 
 def test_qaava_connection_params_without_saving_username_and_pwd(initialize_db_settings2, database_params):
     set_qaava_connection(LandUsePlanEnum.detailed, CONN_NAME)
-    params = get_db_connection_params(LandUsePlanEnum.detailed, QGIS_APP)
+    params = get_db_connection_params(LandUsePlanEnum.detailed)
     expected_params = {**database_params, **{"user": None, "password": None}}
     assert params == expected_params
 

--- a/Qaava/test/test_integration_db.py
+++ b/Qaava/test/test_integration_db.py
@@ -68,3 +68,5 @@ def test_db_initializer_with_general_plan(new_project, db):
     rows = db1.execute_select("SELECT nspname FROM pg_catalog.pg_namespace;")
     expected_schemas = {('yleiskaava',), ('koodistot',), ('kaavan_lisatiedot',)}
     assert set(rows).intersection(expected_schemas) == expected_schemas
+    rows = db1.execute_select("SELECT name FROM qgis_projects")
+    assert rows == [('qaava-yleiskaava',)]

--- a/Qaava/test/test_integration_db.py
+++ b/Qaava/test/test_integration_db.py
@@ -68,5 +68,5 @@ def test_db_initializer_with_general_plan(new_project, db):
     rows = db1.execute_select("SELECT nspname FROM pg_catalog.pg_namespace;")
     expected_schemas = {('yleiskaava',), ('koodistot',), ('kaavan_lisatiedot',)}
     assert set(rows).intersection(expected_schemas) == expected_schemas
-    rows = db1.execute_select("SELECT name FROM qgis_projects")
-    assert rows == [('qaava-yleiskaava',)]
+    available_projects = initializer.get_available_projects()
+    assert available_projects == ['qaava-yleiskaava']

--- a/Qaava/test/test_model.py
+++ b/Qaava/test/test_model.py
@@ -61,3 +61,9 @@ def test_general_plan_schema_fetch(new_project):
     plan = GeneralLandUsePlan()
     schema = plan.fetch_schema()
     assert len(schema) > 1000
+
+
+def test_project_fetch(new_project, database_params):
+    plan = GeneralLandUsePlan()
+    project_sql = plan.fetch_project(conn_params=database_params, auth_cfg_id='test-auth-cfg')
+    print(project_sql)

--- a/Qaava/test/test_model.py
+++ b/Qaava/test/test_model.py
@@ -63,7 +63,13 @@ def test_general_plan_schema_fetch(new_project):
     assert len(schema) > 1000
 
 
+def test_general_plan_fetch_versions(new_project):
+    plan = GeneralLandUsePlan()
+    assert plan.newest_version == (0, 1, 0)
+    assert plan.available_versions == [(0, 1, 0)]
+
+
 def test_project_fetch(new_project, database_params):
     plan = GeneralLandUsePlan()
     project_sql = plan.fetch_project(conn_params=database_params, auth_cfg_id='test-auth-cfg')
-    print(project_sql)
+    assert len(project_sql) > 1000

--- a/Qaava/ui/base_panel.py
+++ b/Qaava/ui/base_panel.py
@@ -78,14 +78,19 @@ class BasePanel:
         """Setup the UI for the panel."""
         raise QgsPluginNotImplementedException
 
-    def run(self):
+    def run(self, method='_run'):
+        if not method:
+            method = '_run'
         self._start_process()
         try:
-            self._run()
+            # use dispatch pattern to invoke method with same name
+            if not hasattr(self, method):
+                raise QgsPluginException(f'Class does not have a method {method}')
+            getattr(self, method)()
         except QgsPluginException as e:
-            LOGGER.exception(tr(u"Unhandled plugin exception occurred. Details: "), bar_msg(e))
+            LOGGER.exception(str(e), extra=e.bar_msg)
         except Exception as e:
-            LOGGER.exception(tr(u"Unhandled exception occurred. Details: "), bar_msg(e))
+            LOGGER.exception(tr('Unhandled exception occurred'), extra=bar_msg(e))
         finally:
             self._end_process()
 

--- a/Qaava/ui/db_panel.py
+++ b/Qaava/ui/db_panel.py
@@ -40,8 +40,11 @@ from qgis.core import QgsApplication
 from .base_panel import BasePanel
 from ..core.db.db_initializer import DatabaseInitializer
 from ..core.db.db_utils import get_existing_database_connections
+from ..core.db.qgis_project_utils import load_project
 from ..definitions.qui import Panels
 from ..model.land_use_plan import LandUsePlanEnum
+from ..qgis_plugin_tools.tools.custom_logging import bar_msg
+from ..qgis_plugin_tools.tools.i18n import tr
 from ..qgis_plugin_tools.tools.resources import plugin_name
 
 LOGGER = logging.getLogger(plugin_name())
@@ -59,7 +62,14 @@ class DbPanel(BasePanel):
 
         self.dlg.refreshPushButton.clicked.connect(self.on_refreshPushButton_clicked)
         self.dlg.agreedCheckBox.clicked.connect(self.on_agreedCheckBox_stateChanged)
+        self.dlg.dbComboBox.currentTextChanged.connect(lambda _: self.set_available_projects([]))
+        self.dlg.cb_projects.currentTextChanged.connect(
+            lambda _: self.dlg.btn_db_open_project.setEnabled(len(self.dlg.cb_projects.currentText()) > 0))
+        self.dlg.btn_db_open_project.clicked.connect(self.open_project)
+
+        # Run connections
         self.dlg.btn_db_initialize.clicked.connect(self.run)
+        self.dlg.btn_db_register.clicked.connect(lambda _: self.run('register'))
 
         self.dlg.agreedCheckBox.setChecked(False)
         self.on_agreedCheckBox_stateChanged()
@@ -80,14 +90,34 @@ class DbPanel(BasePanel):
 
     def on_agreedCheckBox_stateChanged(self):
         self.dlg.btn_db_initialize.setEnabled(self.dlg.agreedCheckBox.isChecked())
+        self.dlg.btn_db_open_project.setEnabled(self.dlg.agreedCheckBox.isChecked())
 
-    def get_db(self):
+    def set_available_projects(self, projects):
+        self.dlg.cb_projects.clear()
+        self.dlg.cb_projects.addItems(projects)
+
+    def get_db(self) -> str:
         return self.dlg.dbComboBox.currentText()
 
-    def get_plan(self):
+    def get_plan(self) -> str:
         return self.dlg.dmComboBox.currentText()
+
+    def open_project(self):
+        project_name = self.dlg.cb_projects.currentText()
+        if len(project_name):
+            plan_enum = LandUsePlanEnum[self.get_plan()]
+            load_project(project_name, plan_enum)
 
     def _run(self):
         # noinspection PyArgumentList
         initializer = DatabaseInitializer(self.dlg, QgsApplication.instance())
         initializer.initialize_database(self.get_db(), self.get_plan())
+        projects = initializer.get_available_projects()
+        self.set_available_projects(projects)
+
+    def register(self):
+        initializer = DatabaseInitializer(self.dlg, QgsApplication.instance())
+        initializer.register_database(self.get_db(), self.get_plan())
+        LOGGER.info(tr(f'Database registered'), extra=bar_msg(self.get_db(), success=True))
+        projects = initializer.get_available_projects()
+        self.set_available_projects(projects)


### PR DESCRIPTION
#### Core changes:
* Fetch newest version information from Qaava repository
* Save db username and password as auth config and use those everywhere
* Fetch QGIS project SQL from Qaava repository, modify it to contain correct connection information for selected db
* Raise exceptions in code used by UI and show use messages in `base_panel` in general case
#### UI changes: 
* Add ability to use existing model database
* Add initial support for opening project files. This should maybe be refactored in #36

![qaava_projektin_avaus](https://user-images.githubusercontent.com/33314057/92459215-128d5d00-f1cf-11ea-916c-ed603cc6cda4.gif)



Resolves to #41. 